### PR TITLE
Refactor board_full/empty functions

### DIFF
--- a/src/game.f03
+++ b/src/game.f03
@@ -16,34 +16,18 @@ module game
   end type TLine
 
 contains
-  function board_empty(board) result(ok)
+  pure function board_empty(board) result(ok)
     integer, intent(in) :: board(board_size_cl,board_size_cl)
     logical :: ok
 
-    integer :: x, y
-
-    ok = .true.
-    do x=1,board_size_cl
-       do y=1,board_size_cl
-          ok = board(x, y) == 0
-          if (.not. ok) return
-       end do
-    end do
+    ok = all(board == 0)
   end function board_empty
-  
-  function board_full(board) result(ok)
+
+  pure function board_full(board) result(ok)
     integer, intent(in) :: board(board_size_cl,board_size_cl)
     logical :: ok
 
-    integer :: x, y
-
-    ok = .true.
-    do x=1,board_size_cl
-       do y=1,board_size_cl
-          ok = board(x, y) /= 0
-          if (.not. ok) return
-       end do
-    end do
+    ok = all(board /= 0)
   end function board_full
 
   pure function in_bounds(p) result(yes)


### PR DESCRIPTION
Change the logic of these functions to be more Fortran-ish instead of being C-ish.

- `pure` is optional, it just enforces certain things, like no side effects
- if you want to make clear that board is an 2D-array, you could add `(:,:)` behind `board` in the comparison